### PR TITLE
fix: improve inflated generic type resolution (v0.1.2)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "il2cpp-bridge-rs"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "Rust library for Unity IL2CPP runtime introspection — resolve classes, invoke methods, and interact with the IL2CPP VM at runtime"
 license = "MIT"

--- a/src/structs/core/hierarchy/type.rs
+++ b/src/structs/core/hierarchy/type.rs
@@ -92,11 +92,14 @@ impl Type {
     /// Resolves concrete generic type arguments for inflated generic types
     /// using `type_get_assembly_qualified_name`.
     fn try_resolve_inflated(&self) -> Option<String> {
+        if !self.name.contains('`') {
+            return None;
+        }
         unsafe {
-            let class_ptr = crate::api::class_from_type(self.address);
-            if class_ptr.is_null() || !crate::api::class_is_inflated(class_ptr) {
-                return None;
-            }
+            // let class_ptr = crate::api::class_from_type(self.address);
+            // if class_ptr.is_null() || !crate::api::class_is_inflated(class_ptr) {
+            //     return None;
+            // }
             let aqn_ptr = crate::api::type_get_assembly_qualified_name(self.address);
             if aqn_ptr.is_null() {
                 return None;
@@ -105,6 +108,10 @@ impl Type {
                 .to_string_lossy()
                 .into_owned();
             crate::api::free(aqn_ptr as *mut c_void);
+
+            if !aqn.contains("[[") {
+                return None;
+            }
 
             let cleaned = super::type_fmt::strip_assembly_qualifiers(&aqn);
             Some(super::type_fmt::format_type_name_str(&cleaned))


### PR DESCRIPTION
## Summary
- Replace `class_from_type`/`class_is_inflated` API calls with name-based backtick check for early detection of generic types
- Add guard against non-generic assembly qualified names (no `[[`) before parsing
- Bump version to 0.1.2

## Test plan
- [x] Verify generic types (e.g. `List<T>`, `Dictionary<K,V>`) still resolve correctly
- [x] Verify non-generic types are not incorrectly treated as inflated generics
- [x] Confirm no regressions in type name formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)