### PR TITLE
fix: replace custom dev_release cfg with debug_assertions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,5 +41,3 @@ panic = "abort"
 strip = "debuginfo"
 overflow-checks = false
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(dev_release)'] }

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,1 @@
-fn main() {
-    if std::env::var("PROFILE").as_deref() == Ok("debug") {
-        println!("cargo:rustc-cfg=dev_release");
-    }
-}
+fn main() {}

--- a/src/api/core/cache.rs
+++ b/src/api/core/cache.rs
@@ -4,7 +4,7 @@
 //! point for metadata-driven workflows. Most users should use the helper
 //! functions in this module rather than traversing IL2CPP metadata manually.
 use super::api;
-#[cfg(dev_release)]
+#[cfg(debug_assertions)]
 use crate::logger;
 use dashmap::DashMap;
 use once_cell::sync::Lazy;
@@ -128,7 +128,7 @@ pub fn init() -> bool {
         match load_all_assemblies() {
             Ok(_assembly_count) => match hydrate_all_classes() {
                 Ok(_class_count) => {
-                    #[cfg(dev_release)]
+                    #[cfg(debug_assertions)]
                     logger::info(&format!(
                         "Cache initialized: {} assemblies loaded, {} classes hydrated",
                         _assembly_count, _class_count
@@ -136,13 +136,13 @@ pub fn init() -> bool {
                     true
                 }
                 Err(_e) => {
-                    #[cfg(dev_release)]
+                    #[cfg(debug_assertions)]
                     logger::error(&format!("Cache init failed during class hydration: {}", _e));
                     false
                 }
             },
             Err(_e) => {
-                #[cfg(dev_release)]
+                #[cfg(debug_assertions)]
                 logger::error(&format!("Cache init failed: {}", _e));
                 false
             }
@@ -200,7 +200,7 @@ pub(crate) fn hydrate_all_classes() -> Result<usize, String> {
             CACHE.assemblies.insert(name, Arc::new(new_assembly));
         }
     }
-    #[cfg(dev_release)]
+    #[cfg(debug_assertions)]
     logger::info(&format!("Hydrated {} classes", hydrated_class_count));
     Ok(hydrated_class_count)
 }

--- a/src/api/core/runtime/thread.rs
+++ b/src/api/core/runtime/thread.rs
@@ -1,6 +1,6 @@
 //! IL2CPP thread attachment and lifecycle helpers.
 use super::super::api;
-#[cfg(dev_release)]
+#[cfg(debug_assertions)]
 use crate::logger;
 use std::ffi::c_void;
 use std::ptr;
@@ -46,7 +46,7 @@ impl Thread {
             unsafe {
                 api::thread_detach(self.thread_ptr);
             }
-            #[cfg(dev_release)]
+            #[cfg(debug_assertions)]
             logger::info("Thread manually detached from IL2CPP");
             self.thread_ptr = ptr::null_mut();
         }
@@ -87,7 +87,7 @@ impl Thread {
     pub fn attach(auto_detach: bool) -> Option<Self> {
         unsafe {
             if Self::is_attached() {
-                #[cfg(dev_release)]
+                #[cfg(debug_assertions)]
                 logger::info("Thread already attached to IL2CPP, returning existing thread");
                 return Self::current();
             }
@@ -95,7 +95,7 @@ impl Thread {
             let domain_ptr = api::domain_get();
 
             if domain_ptr.is_null() {
-                #[cfg(dev_release)]
+                #[cfg(debug_assertions)]
                 logger::error("Failed to get IL2CPP domain for thread attachment");
                 return None;
             }
@@ -103,11 +103,11 @@ impl Thread {
             let thread_ptr = api::thread_attach(domain_ptr);
 
             if thread_ptr.is_null() {
-                #[cfg(dev_release)]
+                #[cfg(debug_assertions)]
                 logger::error("Failed to attach thread to IL2CPP");
                 None
             } else {
-                #[cfg(dev_release)]
+                #[cfg(debug_assertions)]
                 logger::info("Thread successfully attached to IL2CPP");
                 Some(Self::from_ptr(thread_ptr, auto_detach))
             }
@@ -155,7 +155,7 @@ impl Drop for Thread {
             unsafe {
                 api::thread_detach(self.thread_ptr);
             }
-            #[cfg(dev_release)]
+            #[cfg(debug_assertions)]
             logger::info("Thread automatically detached from IL2CPP");
             self.thread_ptr = ptr::null_mut();
         }

--- a/src/api/debugging/cs.rs
+++ b/src/api/debugging/cs.rs
@@ -1,6 +1,6 @@
 //! Metadata dump helpers that emit C#-like pseudo-code.
 use crate::api::{cache, Application};
-#[cfg(dev_release)]
+#[cfg(debug_assertions)]
 use crate::logger;
 use crate::structs::Assembly;
 use std::fs::File;
@@ -68,7 +68,7 @@ fn get_dump_dir(base_path: Option<&str>) -> Option<PathBuf> {
     let dump_dir = Path::new(&root).join("dump");
 
     if let Err(_e) = std::fs::create_dir_all(&dump_dir) {
-        #[cfg(dev_release)]
+        #[cfg(debug_assertions)]
         logger::error(&format!("Failed to create dump directory: {}", _e));
         return None;
     }
@@ -80,7 +80,7 @@ fn get_dump_dir(base_path: Option<&str>) -> Option<PathBuf> {
 fn dump_assemblies_impl(base_path: Option<&str>, single_file_name: Option<&str>) -> Option<String> {
     let dump_dir = get_dump_dir(base_path)?;
 
-    #[cfg(dev_release)]
+    #[cfg(debug_assertions)]
     logger::info(&format!("Dumping assemblies to {:?}...", dump_dir));
 
     let assemblies = sorted_assemblies();
@@ -91,7 +91,7 @@ fn dump_assemblies_impl(base_path: Option<&str>, single_file_name: Option<&str>)
         let file = match File::create(&path) {
             Ok(f) => f,
             Err(_e) => {
-                #[cfg(dev_release)]
+                #[cfg(debug_assertions)]
                 logger::error(&format!("Failed to create dump file: {}", _e));
                 return None;
             }
@@ -100,14 +100,14 @@ fn dump_assemblies_impl(base_path: Option<&str>, single_file_name: Option<&str>)
 
         // Image index block at the top
         if let Err(_e) = write_image_list(&mut writer, &assemblies) {
-            #[cfg(dev_release)]
+            #[cfg(debug_assertions)]
             logger::error(&format!("Failed to write image list: {}", _e));
         }
 
         // Classes in sorted order
         for assembly in &assemblies {
             if let Err(_e) = write_assembly(&mut writer, assembly) {
-                #[cfg(dev_release)]
+                #[cfg(debug_assertions)]
                 logger::error(&format!(
                     "Failed to write assembly {}: {}",
                     assembly.name, _e
@@ -116,12 +116,12 @@ fn dump_assemblies_impl(base_path: Option<&str>, single_file_name: Option<&str>)
         }
 
         if let Err(_e) = writer.flush() {
-            #[cfg(dev_release)]
+            #[cfg(debug_assertions)]
             logger::error(&format!("Failed to flush writer: {}", _e));
             return None;
         }
 
-        #[cfg(dev_release)]
+        #[cfg(debug_assertions)]
         logger::info(&format!("Dumped all assemblies to {:?}", path));
         Some(path.to_string_lossy().into_owned())
     } else {
@@ -132,7 +132,7 @@ fn dump_assemblies_impl(base_path: Option<&str>, single_file_name: Option<&str>)
             let file = match File::create(&path) {
                 Ok(f) => f,
                 Err(_e) => {
-                    #[cfg(dev_release)]
+                    #[cfg(debug_assertions)]
                     logger::error(&format!(
                         "Failed to create dump file for {}: {}",
                         assembly.name, _e
@@ -143,12 +143,12 @@ fn dump_assemblies_impl(base_path: Option<&str>, single_file_name: Option<&str>)
             let mut writer = BufWriter::new(file);
 
             if let Err(_e) = write_image_list(&mut writer, &assemblies) {
-                #[cfg(dev_release)]
+                #[cfg(debug_assertions)]
                 logger::error(&format!("Failed to write image list: {}", _e));
             }
 
             if let Err(_e) = write_assembly(&mut writer, assembly) {
-                #[cfg(dev_release)]
+                #[cfg(debug_assertions)]
                 logger::error(&format!(
                     "Failed to write assembly {}: {}",
                     assembly.name, _e
@@ -156,12 +156,12 @@ fn dump_assemblies_impl(base_path: Option<&str>, single_file_name: Option<&str>)
             }
 
             if writer.flush().is_ok() {
-                #[cfg(dev_release)]
+                #[cfg(debug_assertions)]
                 logger::info(&format!("Successfully dumped assembly {}", assembly.name));
             }
         }
 
-        #[cfg(dev_release)]
+        #[cfg(debug_assertions)]
         logger::info("Dumped all assemblies");
         Some(dump_dir.to_string_lossy().into_owned())
     }
@@ -186,28 +186,28 @@ pub fn dump_assembly(assembly_to_dump: Option<&str>) -> Option<()> {
     let file = match File::create(&path) {
         Ok(f) => f,
         Err(_e) => {
-            #[cfg(dev_release)]
+            #[cfg(debug_assertions)]
             logger::error(&format!("Failed to create dump file: {}", _e));
             return None;
         }
     };
     let mut writer = BufWriter::new(file);
 
-    #[cfg(dev_release)]
+    #[cfg(debug_assertions)]
     logger::info(&format!("Dumping assembly {}", target_name));
 
     let assemblies = sorted_assemblies();
 
     // Image index block at the top
     if let Err(_e) = write_image_list(&mut writer, &assemblies) {
-        #[cfg(dev_release)]
+        #[cfg(debug_assertions)]
         logger::error(&format!("Failed to write image list: {}", _e));
     }
 
     for assembly in &assemblies {
         if assembly.name.contains(target_name) {
             if let Err(_e) = write_assembly(&mut writer, assembly) {
-                #[cfg(dev_release)]
+                #[cfg(debug_assertions)]
                 logger::error(&format!("Failed to write assembly header: {}", _e));
                 return None;
             }
@@ -215,12 +215,12 @@ pub fn dump_assembly(assembly_to_dump: Option<&str>) -> Option<()> {
     }
 
     if let Err(_e) = writer.flush() {
-        #[cfg(dev_release)]
+        #[cfg(debug_assertions)]
         logger::error(&format!("Failed to flush writer: {}", _e));
         return None;
     }
 
-    #[cfg(dev_release)]
+    #[cfg(debug_assertions)]
     logger::info(&format!("Dumped assembly to {:?}", path));
     Some(())
 }


### PR DESCRIPTION
## Summary

- Replaces all `#[cfg(dev_release)]` gates with the built-in `#[cfg(debug_assertions)]` across `cache.rs`, `thread.rs`, and `cs.rs` (33 occurrences).
- Removes the custom `dev_release` cfg emission from `build.rs` and the corresponding `check-cfg` lint entry from `Cargo.toml`.
- Debug logs now automatically compile in for debug builds and compile out for release builds — including when the crate is used as a dependency.

Closes #5

## Testing

- `cargo check` passes cleanly with no warnings.
- Verified zero remaining references to `dev_release` in the codebase.
