### PR TITLE
fix: windows-sys 0.61 GetModuleHandleA returns *mut c_void, use is_null

### DIFF
--- a/src/memory/info/image.rs
+++ b/src/memory/info/image.rs
@@ -143,7 +143,7 @@ mod platform {
         let c_name = CString::new(name).ok()?;
         unsafe {
             let handle = GetModuleHandleA(c_name.as_ptr() as *const u8);
-            if handle == 0 {
+            if handle.is_null() {
                 None
             } else {
                 Some(handle as usize)

--- a/src/memory/info/symbol.rs
+++ b/src/memory/info/symbol.rs
@@ -169,7 +169,7 @@ mod platform {
         unsafe {
             // Null handle returns the calling process module, similar to RTLD_DEFAULT on Unix.
             let handle = GetModuleHandleA(std::ptr::null());
-            if handle == 0 {
+            if handle.is_null() {
                 return Err(SymbolError::NotFound(symbol.into()));
             }
             let addr = GetProcAddress(handle, c_str.as_ptr() as *const u8);


### PR DESCRIPTION
compile issue fix