### PR TITLE
fix: add dlopen fallback for Android 14+ symbol resolution

### DIFF
--- a/src/memory/info/symbol.rs
+++ b/src/memory/info/symbol.rs
@@ -147,12 +147,29 @@ mod platform {
     pub fn raw_resolve(symbol: &str) -> Result<usize, SymbolError> {
         let c_str = CString::new(symbol).map_err(|_| SymbolError::StringError)?;
         unsafe {
+            // Try RTLD_DEFAULT first (works when the library was loaded with GLOBAL)
             let addr_ptr = libc::dlsym(libc::RTLD_DEFAULT, c_str.as_ptr());
-            if addr_ptr.is_null() {
-                Err(SymbolError::NotFound(symbol.into()))
-            } else {
-                Ok(addr_ptr as usize)
+            if !addr_ptr.is_null() {
+                return Ok(addr_ptr as usize);
             }
+            // Fallback: Android 14+ linker may refuse to promote LOCAL symbols
+            // even with RTLD_GLOBAL|RTLD_NOLOAD. Resolve via the target image's
+            // own handle instead (handle intentionally not dlclose'd — the library
+            // stays loaded for the process lifetime, so the symbol pointer remains valid).
+            if let Some(target) = crate::init::TARGET_IMAGE_NAME.get() {
+                let c_name = match CString::new(target.as_str()) {
+                    Ok(c) => c,
+                    Err(_) => return Err(SymbolError::NotFound(symbol.into())),
+                };
+                let handle = libc::dlopen(c_name.as_ptr(), libc::RTLD_NOLOAD);
+                if !handle.is_null() {
+                    let addr = libc::dlsym(handle, c_str.as_ptr());
+                    if !addr.is_null() {
+                        return Ok(addr as usize);
+                    }
+                }
+            }
+            Err(SymbolError::NotFound(symbol.into()))
         }
     }
 }


### PR DESCRIPTION
## Summary

On Android 14+, the dynamic linker may refuse to promote LOCAL symbols even when `RTLD_GLOBAL | RTLD_NOLOAD` is used during `dlopen`. This causes `dlsym(RTLD_DEFAULT, ...)` to fail for symbols in `GameAssembly.so` on affected devices, even after `promote_library_to_global` has been called.

## Changes

Add a fallback path in `raw_resolve` (Linux/Android): when `dlsym(RTLD_DEFAULT)` returns NULL, attempt resolution via the target image's own handle obtained with `dlopen(RTLD_NOLOAD)`.

## Safety

- The `dlopen` handle is intentionally not `dlclose`'d — the target library stays loaded for the process lifetime (Unity holds its own reference), so the symbol pointer remains valid.
- The `CString` construction from `TARGET_IMAGE_NAME` uses `match` instead of `unwrap()` to avoid panics on malformed names.
- This is a no-op on non-Linux/Android platforms since the fallback lives inside a `cfg(linux|android)` module.

## Validation

- `cargo check` passes on Windows (x86_64-pc-windows-msvc)
- `cargo clippy` passes with no new warnings
